### PR TITLE
Add disk-limit as option, and bump up clouddriver's memory

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,5 +25,6 @@
 	ignore = dirty
 [submodule "deck"]
 	path = deck
-	url = https://github.com/spinnaker/deck.git
+	url = https://github.com/gregturn/deck.git
 	ignore = dirty
+	branch = deployer

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spinnaker:
     - name: clouddriver
       artifact: clouddriver-web
       properties:
-        spring.cloud.deployer.cloudfoundry.memory: 2048
+        spring.cloud.deployer.cloudfoundry.memory: 4096
     - name: deck
       artifact: deck-ui
       properties:


### PR DESCRIPTION
While deploying spring-cloud-spinnaker through spinnaker, discovered need to alter disk limits. Also, appears clouddriver needs at 4GB using current in-memory solution.