### PR TITLE
Slow down polling rate

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 spinnaker:
   modules:
     - name: clouddriver
-      artifact: org.springframework.spinnaker:clouddriver-app:1.0.0.BUILD-SNAPSHOT
+      artifact: org.springframework.spinnaker:clouddriver-app:1.0.1.BUILD-SNAPSHOT
       properties:
         memory: 4096
         disk: 2048

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,8 @@ spinnaker:
         memory: 4096
         disk: 2048
         cf.asyncOperationTimeoutSecondsDefault: 1200 # 20 minutes
+        redis.poll.intervalSeconds: 120 # CATS polling cycle
+        redis.poll.timeoutSeconds: 300
     - name: deck
       artifact: org.springframework.spinnaker.deck:deck-ui:2.924.0-SNAPSHOT
       properties:


### PR DESCRIPTION
Polling CF every 30 seconds is causing clouddriver to hit a rate limit. Slowing down the rate as well as improving the efficiency of the poll cycle is needed.