### PR TITLE
Make the HTTPS/HTTP setting between modules optional

### DIFF
--- a/src/main/js/Modules.js
+++ b/src/main/js/Modules.js
@@ -158,6 +158,7 @@ class Modules extends React.Component {
 
 		data[this.props.settings.domain] = this.props.settings[this.props.settings.domain]
 		data['namespace'] = this.getNamespace()
+		data['services.default.protocol'] = this.props.settings[this.props.settings.securedChannels] ? 'https' : 'http'
 
 		let api = this.props.settings[this.props.settings.api]
 		let org = this.props.settings[this.props.settings.org]

--- a/src/main/js/Settings.js
+++ b/src/main/js/Settings.js
@@ -265,6 +265,10 @@ class Settings extends React.Component {
 								   name={this.props.settings.repoPassword}
 								   handleChange={this.handleChange}
 								   settings={this.props.settings} />
+					<CheckboxInput label="SSL? (self signed certs not allowed)"
+								   name={this.props.settings.securedChannels}
+								   handleChange={this.handleChange}
+								   settings={this.props.settings} />
 					<CheckboxInput label="Jenkins?"
 								   name={this.props.settings.jenkinsEnabled}
 								   handleChange={this.handleChange}

--- a/src/main/js/app.js
+++ b/src/main/js/app.js
@@ -61,7 +61,9 @@ class Application extends React.Component {
 			'providers.cf.secondaryCredentials.api': '',
 			'providers.cf.secondaryCredentials.console': '',
 			'providers.cf.secondaryCredentials.org': '',
-			'providers.cf.secondaryCredentials.space': ''
+			'providers.cf.secondaryCredentials.space': '',
+			securedChannels: 'use.securedChannels',
+			'use.securedChannels': true
 		}
 		this.removeEntry = this.removeEntry.bind(this)
 		this.updateSetting = this.updateSetting.bind(this)


### PR DESCRIPTION
Defaults to HTTPS, which is the current state and the recommended state if a cert is published. But gives the option to to switch off in the event self signed certs are used in a private cloud.

Resolves #123